### PR TITLE
fixing Substack link

### DIFF
--- a/ltud.html
+++ b/ltud.html
@@ -65,8 +65,8 @@ title: Apologetic Millennial
           <b>With enough traction and energy, you can help me find an agent</b> and get us one step closer to the
           moral awakening that is already unfolding. Please consider subscribing to my
           <a href="https://medium.com/@apologetic_millennial" target="_blank">Medium</a>, 
-          <a href="https://apologeticmillennial.substack.com/" target="_blank">Substack</a, and
-          <a href="https://instagram.com/apologetic_millennial/?hl=en" target="_blank">Instagram</a> accounts
+          <a href="https://apologeticmillennial.substack.com/" target="_blank">Substack</a>, and 
+          <a href="https://instagram.com/apologetic_millennial/?hl=en" target="_blank">Instagram</a> accounts, 
           and joining my monthly <a href="/newsletter.html" target="_blank">newsletter</a>.
           <a href="/blog/index.html">Blog posts</a> available on this site are
           color-coded to highlight the moral foundations at work. Last but not least, check out some phenomenal


### PR DESCRIPTION
missing ending carrot for Substack link: "</a" changed to "</a>"